### PR TITLE
Fix simple editor HTML wrapper handling

### DIFF
--- a/src/app/(app)/templates/formulario-template/page.tsx
+++ b/src/app/(app)/templates/formulario-template/page.tsx
@@ -42,6 +42,7 @@ import type { Editor } from '@tiptap/react';
 import GrapesNewsletterBuilder from '@/components/custom/grapes-newsletter-builder';
 import { SimpleEditor } from '@/components/tiptap-templates/simple/simple-editor';
 import { SIMPLE_EDITOR_EMAIL_CSS } from '@/styles/simple-editor-email';
+import { extractEditorHtml } from '@/lib/tiptap-utils';
 
 export default function FormularioTemplateSinImagen({
   templateSeleccionado,
@@ -410,12 +411,14 @@ export default function FormularioTemplateSinImagen({
                   <div className="w-full h-[600px] mt-2">
                     <SimpleEditor
                       templateId={templateSeleccionado?.id ?? ''}
-                      initialContent={templateSeleccionado?.mensaje}
+                      initialContent={extractEditorHtml(
+                        templateSeleccionado?.mensaje || ''
+                      )}
                       onInit={handleEditarInit}
                       onUpdate={(html) =>
                         setValue(
                           'mensaje',
-                          `<style>${SIMPLE_EDITOR_EMAIL_CSS}</style>${html}`
+                          `<style>${SIMPLE_EDITOR_EMAIL_CSS}</style><div class="simple-editor-content">${html}</div>`
                         )
                       }
                     />

--- a/src/lib/tiptap-utils.ts
+++ b/src/lib/tiptap-utils.ts
@@ -312,3 +312,21 @@ export function sanitizeUrl(
   }
   return '#';
 }
+
+/**
+ * Removes the wrapping style tag and `.simple-editor-content` div used to
+ * store TipTap content for emails. Returns just the inner HTML that the editor
+ * expects.
+ */
+export function extractEditorHtml(html: string): string {
+  if (!html) return html;
+
+  let cleaned = html.replace(/<style[^>]*>[\s\S]*?<\/style>/i, '');
+  const match = cleaned.match(
+    /<div class="simple-editor-content">([\s\S]*)<\/div>/i
+  );
+  if (match) {
+    cleaned = match[1];
+  }
+  return cleaned.trim();
+}


### PR DESCRIPTION
## Summary
- keep simple editor styles inside `.simple-editor-content`
- add `extractEditorHtml` helper to strip saved wrapper
- use the helper for initial editor content

## Testing
- `npm run lint` *(fails: `next` not found)*
- `npm run typecheck` *(fails: cannot find modules)*

------
https://chatgpt.com/codex/tasks/task_e_6865280d96b083288a6c4e4992040cca