### PR TITLE
Add image style controls

### DIFF
--- a/src/components/custom/image-style-dropdown.tsx
+++ b/src/components/custom/image-style-dropdown.tsx
@@ -1,0 +1,86 @@
+'use client'
+
+import * as React from 'react'
+import { useContext } from 'react'
+import { EditorContext } from '@tiptap/react'
+import { Button } from '@/components/tiptap-ui-primitive/button'
+import Tippy from '@tippyjs/react'
+
+import { ImagePlusIcon } from '@/components/tiptap-icons/image-plus-icon'
+import { AlignLeftIcon } from '@/components/tiptap-icons/align-left-icon'
+import { AlignCenterIcon } from '@/components/tiptap-icons/align-center-icon'
+import { AlignRightIcon } from '@/components/tiptap-icons/align-right-icon'
+
+interface ImageStyleDropdownProps {
+  isOpen: boolean
+  onToggle: () => void
+}
+
+const SIZES = [
+  { label: '25%', value: '25%' },
+  { label: '50%', value: '50%' },
+  { label: '75%', value: '75%' },
+  { label: '100%', value: '100%' },
+]
+
+const ALIGN = [
+  { label: 'Izquierda', value: 'left', Icon: AlignLeftIcon },
+  { label: 'Centrar', value: 'center', Icon: AlignCenterIcon },
+  { label: 'Derecha', value: 'right', Icon: AlignRightIcon },
+]
+
+export default function ImageStyleDropdown({ isOpen, onToggle }: ImageStyleDropdownProps) {
+  const { editor } = useContext(EditorContext)
+  if (!editor) return null
+
+  return (
+    <div className="relative">
+      <Tippy
+        content={<div className="flex flex-col items-center"><span>Opciones de imagen</span></div>}
+        delay={[500, 0]}
+        placement="top"
+        animation="shift-away"
+        arrow
+      >
+        <Button onClick={onToggle} aria-label="Opciones de imagen" data-style="ghost">
+          <ImagePlusIcon className="tiptap-button-icon" />
+        </Button>
+      </Tippy>
+
+      {isOpen && (
+        <div
+          className="absolute right-0 mt-1 w-36 bg-white dark:bg-gray-800 border rounded shadow-lg z-20 p-2 space-y-2"
+          onWheel={(e) => e.stopPropagation()}
+        >
+          <div className="text-xs font-medium px-2">Tamaño</div>
+          {SIZES.map((size) => (
+            <button
+              key={size.value}
+              className="w-full text-left px-3 py-1 hover:bg-gray-100 dark:hover:bg-gray-700"
+              onClick={() => {
+                editor.chain().focus().setImageWidth(size.value).run()
+                onToggle()
+              }}
+            >
+              {size.label}
+            </button>
+          ))}
+          <div className="text-xs font-medium px-2 pt-1">Alineación</div>
+          {ALIGN.map(({ label, value, Icon }) => (
+            <button
+              key={value}
+              className="w-full flex items-center gap-2 px-3 py-1 text-left hover:bg-gray-100 dark:hover:bg-gray-700"
+              onClick={() => {
+                editor.chain().focus().setImageAlign(value as any).run()
+                onToggle()
+              }}
+            >
+              <Icon className="tiptap-button-icon" />
+              {label}
+            </button>
+          ))}
+        </div>
+      )}
+    </div>
+  )
+}

--- a/src/components/tiptap-extension/image-style.ts
+++ b/src/components/tiptap-extension/image-style.ts
@@ -1,0 +1,51 @@
+import TiptapImage from '@tiptap/extension-image'
+declare module "@tiptap/core" {
+  interface Commands<ReturnType> {
+    imageStyle: {
+      setImageWidth: (width: string | null) => ReturnType;
+      setImageAlign: (align: "left" | "center" | "right" | null) => ReturnType;
+    };
+  }
+}
+
+
+export const ImageStyle = TiptapImage.extend({
+  addAttributes() {
+    return {
+      ...this.parent?.(),
+      width: {
+        default: null,
+        parseHTML: element => element.getAttribute('data-width'),
+        renderHTML: attrs => {
+          return {
+            'data-width': attrs.width,
+            style: attrs.width ? `width: ${attrs.width};` : null,
+          }
+        },
+      },
+      align: {
+        default: null,
+        parseHTML: element => element.getAttribute('data-align'),
+        renderHTML: attrs => (attrs.align ? { 'data-align': attrs.align } : {}),
+      },
+    }
+  },
+
+  addCommands() {
+    return {
+      ...this.parent?.(),
+      setImageWidth:
+        width =>
+        ({ commands }) => {
+          return commands.updateAttributes('image', { width })
+        },
+      setImageAlign:
+        align =>
+        ({ commands }) => {
+          return commands.updateAttributes('image', { align })
+        },
+    }
+  },
+})
+
+export default ImageStyle

--- a/src/components/tiptap-templates/simple/simple-editor.tsx
+++ b/src/components/tiptap-templates/simple/simple-editor.tsx
@@ -5,7 +5,7 @@ import { EditorContent, EditorContext, useEditor } from '@tiptap/react';
 
 // --- Tiptap Core Extensions ---
 import { StarterKit } from '@tiptap/starter-kit';
-import { Image } from '@tiptap/extension-image';
+import { ImageStyle } from "@/components/tiptap-extension/image-style";
 import { TaskItem } from '@tiptap/extension-task-item';
 import { TaskList } from '@tiptap/extension-task-list';
 import { TextAlign } from '@tiptap/extension-text-align';
@@ -78,6 +78,7 @@ import '@/components/tiptap-templates/simple/simple-editor.scss';
 import content from '@/components/tiptap-templates/simple/data/content.json';
 import PlaceholderDropdown from '@/components/custom/placeHolders';
 import HighlightDropdown from '@/components/custom/highlight-dropdown';
+import ImageStyleDropdown from '@/components/custom/image-style-dropdown';
 
 import TextStyle from '@tiptap/extension-text-style';
 import Color from '@tiptap/extension-color';
@@ -178,13 +179,11 @@ const MainToolbarContent = ({
       </ToolbarGroup>
 
       <ToolbarSeparator />
-
       <ToolbarGroup>
         <ImageUploadButton text="Agregar" />
+        <ImageStyleDropdown isOpen={activeDropdown === 'imageStyle'} onToggle={() => setActiveDropdown(activeDropdown === 'imageStyle' ? null : 'imageStyle')} />
       </ToolbarGroup>
-
       {isMobile && <ToolbarSeparator />}
-
       <Spacer />
     </>
   );
@@ -265,7 +264,7 @@ export function SimpleEditor({
       TaskList,
       TaskItem.configure({ nested: true }),
       Highlight.configure({ multicolor: true }),
-      Image,
+            ImageStyle,
       Typography,
       Superscript,
       Subscript,

--- a/src/styles/email.css
+++ b/src/styles/email.css
@@ -102,3 +102,13 @@
   display: block;
   margin: 0.5em 0;
 }
+.simple-editor-content img[data-align="center"] {
+  display: block;
+  margin-left: auto;
+  margin-right: auto;
+}
+.simple-editor-content img[data-align="right"] {
+  display: block;
+  margin-left: auto;
+}
+

--- a/src/styles/simple-editor-email.ts
+++ b/src/styles/simple-editor-email.ts
@@ -102,5 +102,15 @@ export const SIMPLE_EDITOR_EMAIL_CSS = `/* 1) Imports de TipTap */
   display: block;
   margin: 0.5em 0;
 }
+.simple-editor-content img[data-align="center"] {
+  display: block;
+  margin-left: auto;
+  margin-right: auto;
+}
+.simple-editor-content img[data-align="right"] {
+  display: block;
+  margin-left: auto;
+}
+
 ` as const;
 


### PR DESCRIPTION
## Summary
- extend tiptap Image extension with width and align attributes
- add ImageStyleDropdown to change size and alignment from toolbar
- update SimpleEditor to include image style dropdown
- support image alignment in email editor CSS

## Testing
- `npm run lint` *(fails: `next` not found)*
- `npm run typecheck` *(fails: cannot find modules)*

------
https://chatgpt.com/codex/tasks/task_e_68653792a80083289e29ce82a9a560d4